### PR TITLE
Fix #174: Inconsistent casing in log messages

### DIFF
--- a/pkg/dartino_compiler/lib/src/verbs/create_verb.dart
+++ b/pkg/dartino_compiler/lib/src/verbs/create_verb.dart
@@ -108,9 +108,9 @@ Future<int> createSessionTask(
   SessionState state = createSessionState(name, base, settings);
   SessionState.internalCurrent = state;
   if (settingsUri != null) {
-    state.log("created session with $settingsUri $settings");
+    state.log("Created session with $settingsUri $settings");
   } else {
-    state.log("created session with settings $settings");
+    state.log("Created session with settings $settings");
   }
   return 0;
 }

--- a/pkg/dartino_compiler/lib/src/vm_connection.dart
+++ b/pkg/dartino_compiler/lib/src/vm_connection.dart
@@ -75,7 +75,7 @@ class TcpConnection extends VmConnection {
         onConnectionError,
         test: (e) => e is SocketException);
     handleSocketErrors(socket, socketDescription, log: (String info) {
-      log("Connected to TCP $socketDescription  $info");
+      log("Connected to TCP $info");
     });
     // We send many small packages, so use no-delay.
     socket.setOption(SocketOption.TCP_NODELAY, true);


### PR DESCRIPTION
The repeated 'vmSocket' in 'Connected to TCP ...' was because
the name parameter is part of the info being logged in
pkg/dartino_compiler/lib/src/hub/client_commands.dart::handleSocketErrors

I have not run any tests to verify the fix.

Signed-off-by: Martin Mosegaard Amdisen martin.amdisen@praqma.com
